### PR TITLE
Fix nil decoration

### DIFF
--- a/lib/decoratex.ex
+++ b/lib/decoratex.ex
@@ -138,11 +138,18 @@ defmodule Decoratex do
       This functions just call the configured function to each field passing
       the model structure it self and it store the result in the virtual field.
       """
+
+      @spec decorate(nil) :: nil
+      def decorate(nil), do: nil
+
       @spec decorate(struct) :: struct
       def decorate(element) do
         element.__struct__.__decorations__
         |> Enum.reduce(element, &do_decorate/2)
       end
+
+      @spec decorate(nil, any) :: nil
+      def decorate(nil, _), do: nil
 
       @spec decorate(struct, except: atom) :: struct
       def decorate(element, except: name) when is_atom(name), do: decorate(element, except: [name])

--- a/lib/decoratex.ex
+++ b/lib/decoratex.ex
@@ -144,7 +144,7 @@ defmodule Decoratex do
 
       @spec decorate(struct) :: struct
       def decorate(element) do
-        element.__struct__.__decorations__
+        element.__struct__.__decorations__()
         |> Enum.reduce(element, &do_decorate/2)
       end
 
@@ -159,7 +159,7 @@ defmodule Decoratex do
 
       @spec decorate(struct, except: list(atom)) :: struct
       def decorate(element, except: names) when is_list(names) do
-        decorate(element, Map.keys(element.__struct__.__decorations__) -- names)
+        decorate(element, Map.keys(element.__struct__.__decorations__()) -- names)
       end
 
       @spec decorate(struct, list) :: struct
@@ -171,11 +171,11 @@ defmodule Decoratex do
 
       @spec process_decoration(atom) :: tuple
       defp process_decoration(field) when is_atom(field) do
-        {field, __decorations__[field]}
+        {field, __decorations__()[field]}
       end
       @spec process_decoration(tuple) :: tuple
       defp process_decoration({field, options}) do
-        {field, Map.put(__decorations__[field], :options, options)}
+        {field, Map.put(__decorations__()[field], :options, options)}
       end
 
       @spec do_decorate(tuple, struct) :: struct
@@ -200,7 +200,7 @@ defmodule Decoratex do
   defmacro decorations(do: block) do
     quote do
       unquote(block)
-      def __decorations__, do: @decorations
+      def __decorations__(), do: @decorations
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,8 +13,8 @@ defmodule Decoratex.Mixfile do
      elixirc_paths: elixirc_paths(Mix.env),
      # Docs
      name: "Decoratex",
-     description: description,
-     package: package]
+     description: description(),
+     package: package()]
   end
 
   # Configuration for the OTP application
@@ -45,8 +45,8 @@ defmodule Decoratex.Mixfile do
 
   # Always compile files in "lib". In tests compile also files in
   # "test/support"
-  def elixirc_paths(:test), do: elixirc_paths ++ ["test/support"]
-  def elixirc_paths(_), do: elixirc_paths
+  def elixirc_paths(:test), do: elixirc_paths() ++ ["test/support"]
+  def elixirc_paths(_), do: elixirc_paths()
   def elixirc_paths, do: ["lib"]
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
-  "dialyxir": {:hex, :dialyxir, "0.4.4", "e93ff4affc5f9e78b70dc7bec7b07da44ae1ed3fef38e7113568dd30ad7b01d3", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ecto": {:hex, :ecto, "2.1.3", "ffb24e150b519a4c0e4c84f9eabc8587199389bc499195d5d1a93cd3b2d9a045", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
-  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.4.4", "e93ff4affc5f9e78b70dc7bec7b07da44ae1ed3fef38e7113568dd30ad7b01d3", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.1.3", "ffb24e150b519a4c0e4c84f9eabc8587199389bc499195d5d1a93cd3b2d9a045", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"}}

--- a/test/decoratex_test.exs
+++ b/test/decoratex_test.exs
@@ -85,4 +85,18 @@ defmodule DecoratexTest do
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == nil
   end
+
+  test "return nil when nil is passed" do
+    decorated_model = TestModel.decorate(nil)
+    assert is_nil(decorated_model)
+
+    decorated_model = TestModel.decorate(nil, :module_name)
+    assert is_nil(decorated_model)
+
+    decorated_model = TestModel.decorate(nil, [:module_name, :module_length])
+    assert is_nil(decorated_model)
+
+    decorated_model = TestModel.decorate(nil, except: :module_name)
+    assert is_nil(decorated_model)
+  end
 end

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -10,7 +10,7 @@ defmodule TestModel do
   end
 
   schema "test_models" do
-    add_decorations
+    add_decorations()
   end
 
   def module_name(element) do


### PR DESCRIPTION
Fixes when a nil is passed for decoration.
In that case, a nil is returned as @belaustegui suggested.

Also, fixed some warning in Elixir 1.4 (parenthesis needed in function calls).