### PR TITLE
Move decoratex logic

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 20.2
-elixir 1.6.1
+erlang 20.2.2
+elixir 1.6.4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The package can be installed as simply as adding `decoratex` to your list of dep
 
 ## Usage
 
-1. Add `use Decoratex` to your models.
+1. Add `use Decoratex.Schema` to your models.
 2. Set the decorate fields inside a block of `decorations` function.
 3. Declare each field with `decorate_field name, type, function, options`.
     * Name of the virtual field.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The package can be installed as simply as adding `decoratex` to your list of dep
     * Type of the virtual field.
     * Function to calculate the value of the virtual field. Always receives a struct model as first param.
     * Default options for the function (arity 2) in case you need to use diferent options in each decoration.
-4. Add `add_decorations` inside schema definition.
+4. Add `decorations()` inside schema definition.
 5. Use `decorate` function of your model module.
 
 ```elixir
@@ -59,12 +59,13 @@ defmodule Post do
     field :title, :string
     field :body, :string
 
-    add_decorations
+    timestamps()
+    decorations()
   end
 end
 ```
 
-The decorations definition needs to be placed before schema definition, and then, you should add `add_decorations` inside the schema block. This will automatically add the virtual fields to your model.
+The decorations definition needs to be placed before schema definition, and then, you should add `decorations()` inside the schema block. This will automatically add the virtual fields to your model.
 
 Finally, you can use the `decorate` function of your model module to populate the fields that you need with the function associated to them.
 
@@ -121,4 +122,3 @@ And you can mix simple and decorations with options with a list:
 ```
 |> Post.decorate([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
 ```
-

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The package can be installed as simply as adding `decoratex` to your list of dep
     * Function to calculate the value of the virtual field. Always receives a struct model as first param.
     * Default options for the function (arity 2) in case you need to use diferent options in each decoration.
 4. Add `decorations()` inside schema definition.
-5. Use `Decoratex.perform` function with your model.
+5. Use `Decoratex.decorate` function with your model.
 
 ```elixir
 defmodule Post do
   use Ecto.Schema
-  use Decoratex
+  use Decoratex.Schema
 
   decorations do
     decorate_field :happy_comments_count, :integer, &PostHelper.count_happy_comments/1
@@ -75,19 +75,19 @@ post = Post
 |> Repo.preload(:comments))
 
 # Decorate all fields
-|> Decoratex.perform
+|> Decoratex.decorate
 
 # Decorate one field with an atom
-|> Decoratex.perform(:happy_comments_count)
+|> Decoratex.decorate(:happy_comments_count)
 
 # Decorate some fields with a list
-|> Decoratex.perform([:happy_comments_count, ...])
+|> Decoratex.decorate([:happy_comments_count, ...])
 
 # Decorate all fields except one with except key and an atom
-|> Decoratex.perform(except: :happy_comments_count)
+|> Decoratex.decorate(except: :happy_comments_count)
 
 # Decorate all fields except some with except key and a list
-|> Decoratex.perform(except: [:happy_comments_count, ...])
+|> Decoratex.decorate(except: [:happy_comments_count, ...])
 
 post.happy_comments_count
 234
@@ -104,7 +104,7 @@ decorate_field :mention_comments_count, :integer, &PostHelper.count_mention_comm
 Then, you can pass the options value when the struct is decorated
 
 ```
-|> Decoratex.perform(count_mention_comments: user.nickname)
+|> Decoratex.decorate(count_mention_comments: user.nickname)
 ```
 
 You can use a keyword list for a complex logic, but you need to care about how to manage options in the decoration function (always with arity/2), and the default options in the configurtion.
@@ -114,11 +114,11 @@ decorate_field :censured_comments, {:array, Comment}, &PostHelper.censured_comme
 ```
 
 ```
-|> Decoratex.perform(censured_comments: [pattern: list_of_words, replace: "*"])
+|> Decoratex.decorate(censured_comments: [pattern: list_of_words, replace: "*"])
 ```
 
 And you can mix simple and decorations with options with a list:
 
 ```
-|> Decoratex.perform([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
+|> Decoratex.decorate([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The package can be installed as simply as adding `decoratex` to your list of dep
 
 ```elixir
   def deps do
-    [{:decoratex, "~> 1.0.0"}]
+    [{:decoratex, "~> 1.1.0"}]
   end
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The package can be installed as simply as adding `decoratex` to your list of dep
     * Function to calculate the value of the virtual field. Always receives a struct model as first param.
     * Default options for the function (arity 2) in case you need to use diferent options in each decoration.
 4. Add `decorations()` inside schema definition.
-5. Use `decorate` function of your model module.
+5. Use `Decoratex.perform` function with your model.
 
 ```elixir
 defmodule Post do
@@ -75,19 +75,19 @@ post = Post
 |> Repo.preload(:comments))
 
 # Decorate all fields
-|> Post.decorate
+|> Decoratex.perform
 
 # Decorate one field with an atom
-|> Post.decorate(:happy_comments_count)
+|> Decoratex.perform(:happy_comments_count)
 
 # Decorate some fields with a list
-|> Post.decorate([:happy_comments_count, ...])
+|> Decoratex.perform([:happy_comments_count, ...])
 
 # Decorate all fields except one with except key and an atom
-|> Post.decorate(except: :happy_comments_count)
+|> Decoratex.perform(except: :happy_comments_count)
 
 # Decorate all fields except some with except key and a list
-|> Post.decorate(except: [:happy_comments_count, ...])
+|> Decoratex.perform(except: [:happy_comments_count, ...])
 
 post.happy_comments_count
 234
@@ -104,7 +104,7 @@ decorate_field :mention_comments_count, :integer, &PostHelper.count_mention_comm
 Then, you can pass the options value when the struct is decorated
 
 ```
-|> Post.decorate(count_mention_comments: user.nickname)
+|> Decoratex.perform(count_mention_comments: user.nickname)
 ```
 
 You can use a keyword list for a complex logic, but you need to care about how to manage options in the decoration function (always with arity/2), and the default options in the configurtion.
@@ -114,11 +114,11 @@ decorate_field :censured_comments, {:array, Comment}, &PostHelper.censured_comme
 ```
 
 ```
-|> Post.decorate(censured_comments: [pattern: list_of_words, replace: "*"])
+|> Decoratex.perform(censured_comments: [pattern: list_of_words, replace: "*"])
 ```
 
 And you can mix simple and decorations with options with a list:
 
 ```
-|> Post.decorate([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
+|> Decoratex.perform([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
 ```

--- a/lib/decoratex.ex
+++ b/lib/decoratex.ex
@@ -33,8 +33,8 @@ defmodule Decoratex do
       * Type of the virtual field.
       * Function to calculate the value of the virtual field. Always receives a struct model as first param.
       * Default options for the function (arity 2) in case you need to use diferent options in each decoration.
-  4. Add `add_decorations` inside schema definition.
   5. Use `decorate` function of your model module.
+  4. Add `decorations()` inside schema definition.
 
   ## Usage examples
 
@@ -58,7 +58,8 @@ defmodule Decoratex do
           field :title, :string
           field :body, :string
 
-          add_decorations
+          timestamps()
+          decorations()
         end
       end
 
@@ -132,7 +133,7 @@ defmodule Decoratex do
   @doc false
   defmacro __using__(_) do
     quote do
-      import Decoratex, only: [decorations: 1, add_decorations: 0]
+      import Decoratex, only: [decorations: 0, decorations: 1]
     end
   end
 
@@ -160,6 +161,14 @@ defmodule Decoratex do
       @doc """
       Decorate function adds the ability to a model for load the decorate fields
       to it self.
+  @doc false
+  defmacro decorations do
+    quote do
+      Enum.each(@decorations, fn {name, %{type: type}} ->
+        field(name, type, virtual: true)
+      end)
+    end
+  end
 
       You can load all configured fields, load just one with an atom or some
       with a list.
@@ -268,14 +277,5 @@ defmodule Decoratex do
       end
 
     Module.put_attribute(module, :decorations, {name, decoration})
-  end
-
-  @doc false
-  defmacro add_decorations do
-    quote do
-      Enum.each(@decorations, fn {name, %{type: type}} ->
-        field(name, type, virtual: true)
-      end)
-    end
   end
 end

--- a/lib/decoratex.ex
+++ b/lib/decoratex.ex
@@ -34,7 +34,7 @@ defmodule Decoratex do
       * Function to calculate the value of the virtual field. Always receives a struct model as first param.
       * Default options for the function (arity 2) in case you need to use diferent options in each decoration.
   4. Add `decorations()` inside schema definition.
-  5. Use `Decoratex.perform` function with your model.
+  5. Use `Decoratex.decorate` function with your model.
 
   ## Usage examples
 
@@ -72,19 +72,19 @@ defmodule Decoratex do
   Decorate it as you need:
 
       # Decorate all fields
-      |> Decoratex.perform
+      |> Decoratex.decorate
 
       # Decorate one field with an atom
-      |> Decoratex.perform(:happy_comments_count)
+      |> Decoratex.decorate(:happy_comments_count)
 
       # Decorate some fields with a list
-      |> Decoratex.perform([:happy_comments_count, ...])
+      |> Decoratex.decorate([:happy_comments_count, ...])
 
       # Decorate all fields except one with except key and an atom
-      |> Decoratex.perform(except: :happy_comments_count)
+      |> Decoratex.decorate(except: :happy_comments_count)
 
       # Decorate all fields except some with except key and a list
-      |> Decoratex.perform(except: [:happy_comments_count, ...])
+      |> Decoratex.decorate(except: [:happy_comments_count, ...])
 
   And use ´post.happy_comments_count´ wherever you want as regular post
   attribute in another methods, pattern matching, decoding as JSON...
@@ -102,7 +102,7 @@ defmodule Decoratex do
   Then, you can pass the options value when the struct is decorated
 
       ```
-      |> Decoratex.perform(count_mention_comments: user.nickname)
+      |> Decoratex.decorate(count_mention_comments: user.nickname)
       ```
 
   You can use a keyword list for a complex logic, but you need to care about how to manage options in the decoration function (always with arity/2), and the default options in the configurtion.
@@ -112,13 +112,13 @@ defmodule Decoratex do
       ```
 
       ```
-      |> Decoratex.perform(censured_comments: [pattern: list_of_words, replace: "*"])
+      |> Decoratex.decorate(censured_comments: [pattern: list_of_words, replace: "*"])
       ```
 
   And you can mix simple and decorations with options with a list:
 
       ```
-      |> Decoratex.perform([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
+      |> Decoratex.decorate([:happy_comments_count, censured_comments: [pattern: list_of_words, replace: "*"]])
       ```
 
   ## Reflection
@@ -141,35 +141,34 @@ defmodule Decoratex do
   This functions just call the configured function to each field passing
   the model structure it self and it store the result in the virtual field.
   """
-  @spec perform(nil) :: nil
-  def perform(nil), do: nil
+  @spec decorate(nil) :: nil
+  def decorate(nil), do: nil
 
-  @spec perform(struct) :: struct
-  def perform(%module{} = element) do
-    module.__decorations__ |> Enum.reduce(element, &decorate/2)
+  @spec decorate(struct) :: struct
+  def decorate(%module{} = element) do
+    module.__decorations__ |> Enum.reduce(element, &do_decorate/2)
   end
 
-  @spec perform(nil, any) :: nil
-  def perform(nil, _), do: nil
+  @spec decorate(nil, any) :: nil
+  def decorate(nil, _), do: nil
 
-  @spec perform(struct, except: atom) :: struct
-  def perform(element, except: name) when is_atom(name),
-    do: perform(element, except: [name])
+  @spec decorate(struct, except: atom) :: struct
+  def decorate(element, except: name) when is_atom(name), do: decorate(element, except: [name])
 
-  @spec perform(struct, atom) :: struct
-  def perform(element, name) when is_atom(name), do: perform(element, [name])
+  @spec decorate(struct, atom) :: struct
+  def decorate(element, name) when is_atom(name), do: decorate(element, [name])
 
-  @spec perform(struct, except: list(atom)) :: struct
-  def perform(%module{} = element, except: exceptions) when is_list(exceptions) do
+  @spec decorate(struct, except: list(atom)) :: struct
+  def decorate(%module{} = element, except: exceptions) when is_list(exceptions) do
     names = module.__decorations__ |> Enum.map(fn {name, _decoration} -> name end)
-    perform(element, names -- exceptions)
+    decorate(element, names -- exceptions)
   end
 
-  @spec perform(struct, list) :: struct
-  def perform(%module{} = element, names) when is_list(names) do
+  @spec decorate(struct, list) :: struct
+  def decorate(%module{} = element, names) when is_list(names) do
     names
-    |> Stream.map(&(process_decoration(module, &1)))
-    |> Enum.reduce(element, &decorate/2)
+    |> Stream.map(&process_decoration(module, &1))
+    |> Enum.reduce(element, &do_decorate/2)
   end
 
   @spec process_decoration(atom, atom) :: tuple
@@ -182,23 +181,23 @@ defmodule Decoratex do
     {field, Map.put(module.__decoration__(field), :options, options)}
   end
 
-  @spec decorate(tuple, struct) :: struct
-  defp decorate({name, %{function: function, options: options}}, element) do
-    decorate(element, name, function, options)
+  @spec do_decorate(tuple, struct) :: struct
+  defp do_decorate({name, %{function: function, options: options}}, element) do
+    do_decorate(element, name, function, options)
   end
 
-  @spec decorate(tuple, struct) :: struct
-  defp decorate({name, %{function: function}}, element) do
-    decorate(element, name, function)
+  @spec do_decorate(tuple, struct) :: struct
+  defp do_decorate({name, %{function: function}}, element) do
+    do_decorate(element, name, function)
   end
 
-  @spec decorate(struct, atom, (... -> any), any) :: struct
-  defp decorate(element, name, function, options) do
+  @spec do_decorate(struct, atom, (... -> any), any) :: struct
+  defp do_decorate(element, name, function, options) do
     %{element | name => function.(element, options)}
   end
 
-  @spec decorate(struct, atom, (... -> any)) :: struct
-  defp decorate(element, name, function) do
+  @spec do_decorate(struct, atom, (... -> any)) :: struct
+  defp do_decorate(element, name, function) do
     %{element | name => function.(element)}
   end
 end

--- a/lib/decoratex/schema.ex
+++ b/lib/decoratex/schema.ex
@@ -1,7 +1,10 @@
 defmodule Decoratex.Schema do
   @moduledoc """
-  This module add the macro functions
+  This module add the macro functions for the module schemas to add the decorate
+  fields definition
   """
+
+  alias Decoratex.Schema
 
   @doc false
   defmacro __using__(_) do
@@ -25,7 +28,7 @@ defmodule Decoratex.Schema do
       decorations = Enum.reverse(@decorations)
 
       Module.eval_quoted(__ENV__, [
-        Decoratex.Schema.__decorations__(decorations)
+        Schema.__decorations__(decorations)
       ])
     end
   end
@@ -42,7 +45,7 @@ defmodule Decoratex.Schema do
   @doc false
   defmacro decorate_field(name, type, function, options \\ nil) do
     quote do
-      Decoratex.Schema.__decorate_field__(
+      Schema.__decorate_field__(
         __MODULE__,
         unquote(name),
         unquote(type),

--- a/lib/decoratex/schema.ex
+++ b/lib/decoratex/schema.ex
@@ -1,7 +1,21 @@
 defmodule Decoratex.Schema do
   @moduledoc """
   This module add the macro functions for the module schemas to add the decorate
-  fields definition
+  fields definitions.
+
+  The macro decorations/1 accepts a block with decorate_fields definitions,
+  and decorations/0 add the virtual fields in the ecto schema to keep the values
+  of decoration functions.
+
+    decorations do
+      decorate_field :field_name, :type, &decoration_method/1
+      ...
+    end
+
+    schema "my_schemas" do
+      ...
+      decorations()
+    end
   """
 
   alias Decoratex.Schema

--- a/lib/decoratex/schema.ex
+++ b/lib/decoratex/schema.ex
@@ -1,0 +1,82 @@
+defmodule Decoratex.Schema do
+  @moduledoc """
+  This module add the macro functions
+  """
+
+  @doc false
+  defmacro __using__(_) do
+    quote do
+      import Decoratex.Schema, only: [decorations: 0, decorations: 1]
+    end
+  end
+
+  @doc false
+  defmacro decorations(do: block) do
+    quote do
+      Module.register_attribute(__MODULE__, :decorations, accumulate: true)
+
+      try do
+        import Decoratex.Schema, only: [decorate_field: 3, decorate_field: 4]
+        unquote(block)
+      after
+        :ok
+      end
+
+      decorations = Enum.reverse(@decorations)
+
+      Module.eval_quoted(__ENV__, [
+        Decoratex.Schema.__decorations__(decorations)
+      ])
+    end
+  end
+
+  @doc false
+  defmacro decorations do
+    quote do
+      Enum.each(@decorations, fn {name, %{type: type}} ->
+        field(name, type, virtual: true)
+      end)
+    end
+  end
+
+  @doc false
+  defmacro decorate_field(name, type, function, options \\ nil) do
+    quote do
+      Decoratex.Schema.__decorate_field__(
+        __MODULE__,
+        unquote(name),
+        unquote(type),
+        unquote(function),
+        unquote(options)
+      )
+    end
+  end
+
+  @doc false
+  def __decorations__(decorations) do
+    decorations_quoted =
+      Enum.map(decorations, fn {name, decoration} ->
+        quote do
+          def __decoration__(unquote(name)), do: unquote(Macro.escape(decoration))
+        end
+      end)
+
+    quote do
+      unquote(decorations_quoted)
+      def __decoration__(_), do: nil
+      def __decorations__, do: unquote(Macro.escape(decorations))
+    end
+  end
+
+  @doc false
+  def __decorate_field__(module, name, type, function, options) do
+    decoration =
+      case :erlang.fun_info(function)[:arity] do
+        1 -> %{type: type, function: function}
+        2 -> %{type: type, function: function, options: options}
+        _ -> raise "Fields can only be decorated with functions of arity 1 or 2"
+      end
+
+    Module.put_attribute(module, :decorations, {name, decoration})
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Decoratex.Mixfile do
   use Mix.Project
 
-  @version "1.0.2"
+  @version "1.1.0"
 
   def project do
     [

--- a/test/decoratex_test.exs
+++ b/test/decoratex_test.exs
@@ -10,7 +10,7 @@ defmodule DecoratexTest do
   test "decorate all fields", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> TestModel.decorate()
+      |> Decoratex.perform()
 
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -19,7 +19,7 @@ defmodule DecoratexTest do
   test "decorate one field", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> TestModel.decorate(:module_name)
+      |> Decoratex.perform(:module_name)
 
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == nil
@@ -28,7 +28,7 @@ defmodule DecoratexTest do
   test "decorate other field", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> TestModel.decorate(:module_length)
+      |> Decoratex.perform(:module_length)
 
     assert decorated_model.module_name == nil
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -37,7 +37,7 @@ defmodule DecoratexTest do
   test "decorate a list of fields", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> TestModel.decorate([:module_name, :module_length])
+      |> Decoratex.perform([:module_name, :module_length])
 
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -46,7 +46,7 @@ defmodule DecoratexTest do
   test "not decorate a field", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> TestModel.decorate(except: :module_name)
+      |> Decoratex.perform(except: :module_name)
 
     assert decorated_model.module_name == nil
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -55,7 +55,7 @@ defmodule DecoratexTest do
   test "not decorate a list of fields", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> TestModel.decorate(except: [:module_name, :module_length])
+      |> Decoratex.perform(except: [:module_name, :module_length])
 
     assert decorated_model.module_name == nil
     assert decorated_model.module_length == nil
@@ -66,7 +66,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> TestModel.decorate(module_contains: text)
+      |> Decoratex.perform(module_contains: text)
 
     assert decorated_model.module_contains == TestModel.module_contains?(test_model, text)
   end
@@ -77,7 +77,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> TestModel.decorate(module_replace: [pattern: pattern, replacement: replacement])
+      |> Decoratex.perform(module_replace: [pattern: pattern, replacement: replacement])
 
     assert decorated_model.module_replace ==
              TestModel.module_replace(test_model, pattern: pattern, replacement: replacement)
@@ -90,7 +90,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> TestModel.decorate(
+      |> Decoratex.perform(
         module_contains: text,
         module_replace: [pattern: pattern, replacement: replacement]
       )
@@ -108,7 +108,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> TestModel.decorate([:module_name, module_contains: text])
+      |> Decoratex.perform([:module_name, module_contains: text])
 
     assert decorated_model.module_replace == nil
     assert decorated_model.module_contains == TestModel.module_contains?(test_model, text)
@@ -117,16 +117,16 @@ defmodule DecoratexTest do
   end
 
   test "return nil when nil is passed" do
-    decorated_model = TestModel.decorate(nil)
+    decorated_model = Decoratex.perform(nil)
     assert is_nil(decorated_model)
 
-    decorated_model = TestModel.decorate(nil, :module_name)
+    decorated_model = Decoratex.perform(nil, :module_name)
     assert is_nil(decorated_model)
 
-    decorated_model = TestModel.decorate(nil, [:module_name, :module_length])
+    decorated_model = Decoratex.perform(nil, [:module_name, :module_length])
     assert is_nil(decorated_model)
 
-    decorated_model = TestModel.decorate(nil, except: :module_name)
+    decorated_model = Decoratex.perform(nil, except: :module_name)
     assert is_nil(decorated_model)
   end
 end

--- a/test/decoratex_test.exs
+++ b/test/decoratex_test.exs
@@ -10,7 +10,7 @@ defmodule DecoratexTest do
   test "decorate all fields", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> Decoratex.perform()
+      |> Decoratex.decorate()
 
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -19,7 +19,7 @@ defmodule DecoratexTest do
   test "decorate one field", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> Decoratex.perform(:module_name)
+      |> Decoratex.decorate(:module_name)
 
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == nil
@@ -28,7 +28,7 @@ defmodule DecoratexTest do
   test "decorate other field", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> Decoratex.perform(:module_length)
+      |> Decoratex.decorate(:module_length)
 
     assert decorated_model.module_name == nil
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -37,7 +37,7 @@ defmodule DecoratexTest do
   test "decorate a list of fields", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> Decoratex.perform([:module_name, :module_length])
+      |> Decoratex.decorate([:module_name, :module_length])
 
     assert decorated_model.module_name == TestModel.module_name(test_model)
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -46,7 +46,7 @@ defmodule DecoratexTest do
   test "not decorate a field", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> Decoratex.perform(except: :module_name)
+      |> Decoratex.decorate(except: :module_name)
 
     assert decorated_model.module_name == nil
     assert decorated_model.module_length == TestModel.module_length(test_model)
@@ -55,7 +55,7 @@ defmodule DecoratexTest do
   test "not decorate a list of fields", %{test_model: test_model} do
     decorated_model =
       test_model
-      |> Decoratex.perform(except: [:module_name, :module_length])
+      |> Decoratex.decorate(except: [:module_name, :module_length])
 
     assert decorated_model.module_name == nil
     assert decorated_model.module_length == nil
@@ -66,7 +66,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> Decoratex.perform(module_contains: text)
+      |> Decoratex.decorate(module_contains: text)
 
     assert decorated_model.module_contains == TestModel.module_contains?(test_model, text)
   end
@@ -77,7 +77,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> Decoratex.perform(module_replace: [pattern: pattern, replacement: replacement])
+      |> Decoratex.decorate(module_replace: [pattern: pattern, replacement: replacement])
 
     assert decorated_model.module_replace ==
              TestModel.module_replace(test_model, pattern: pattern, replacement: replacement)
@@ -90,7 +90,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> Decoratex.perform(
+      |> Decoratex.decorate(
         module_contains: text,
         module_replace: [pattern: pattern, replacement: replacement]
       )
@@ -108,7 +108,7 @@ defmodule DecoratexTest do
 
     decorated_model =
       test_model
-      |> Decoratex.perform([:module_name, module_contains: text])
+      |> Decoratex.decorate([:module_name, module_contains: text])
 
     assert decorated_model.module_replace == nil
     assert decorated_model.module_contains == TestModel.module_contains?(test_model, text)
@@ -117,16 +117,16 @@ defmodule DecoratexTest do
   end
 
   test "return nil when nil is passed" do
-    decorated_model = Decoratex.perform(nil)
+    decorated_model = Decoratex.decorate(nil)
     assert is_nil(decorated_model)
 
-    decorated_model = Decoratex.perform(nil, :module_name)
+    decorated_model = Decoratex.decorate(nil, :module_name)
     assert is_nil(decorated_model)
 
-    decorated_model = Decoratex.perform(nil, [:module_name, :module_length])
+    decorated_model = Decoratex.decorate(nil, [:module_name, :module_length])
     assert is_nil(decorated_model)
 
-    decorated_model = Decoratex.perform(nil, except: :module_name)
+    decorated_model = Decoratex.decorate(nil, except: :module_name)
     assert is_nil(decorated_model)
   end
 end

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -14,7 +14,7 @@ defmodule TestModel do
   end
 
   schema "test_models" do
-    add_decorations()
+    decorations()
   end
 
   def module_name(element) do

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -5,7 +5,7 @@ defmodule TestSchema do
   defmacro __using__(_) do
     quote do
       use Ecto.Schema
-      use Decoratex
+      use Decoratex.Schema
     end
   end
 end


### PR DESCRIPTION
This pull request closes #6 .

## Description

The main objective of this PR is to move all the core methods for decorations outside the decorated modules. 

Instead of add this methods with the macro in each module, we can move the methods to Decoratex module and call Decoratex module any time we want to decorate a struct.

Also, we rename the `add_decorations()` to `decorations()`, in the same way than another methods inside the schema, like `timestamps()`.

The users that update the library, just need to rename `add_decorations()` inside schemas and all `.decorate` call for each decorated module with `Decoratex.perform`.

## Tasks

- [x] Rename `add_decorations` method.
- [x] Add reflection method to get decorations of a module.
- [x] Move decoration methods to `Decoratex` module.
- [x] Update documentation.
